### PR TITLE
terraform teamwork fix

### DIFF
--- a/assets/terraform-05-teamwork/src_1/.tflint.hcl
+++ b/assets/terraform-05-teamwork/src_1/.tflint.hcl
@@ -1,0 +1,10 @@
+config {
+  format     = "compact"
+  plugin_dir = "~/.tflint.d/plugins"
+  module     = true
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/assets/terraform-05-teamwork/src_1/main.tf
+++ b/assets/terraform-05-teamwork/src_1/main.tf
@@ -1,13 +1,14 @@
 terraform {
   required_providers {
     yandex = {
-      source = "yandex-cloud/yandex"
+      source  = "yandex-cloud/yandex"
+      version = "0.92.0"
+    }
+    template = {
+      version = "2.2.0"
     }
   }
 
-  # backend "local" {
-
-  # }
   backend "s3" {
     endpoint = "storage.yandexcloud.net"
     bucket   = "tfstate-va-develop"
@@ -41,7 +42,7 @@ module "vpc_dev" {
 }
 
 module "test-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=b266a31489d2681541ea41c5bca6dcfb92ab886a"
   env_name       = "develop"
   network_id     = module.vpc_dev.vpc_id
   subnet_zones   = module.vpc_dev.vpc_zones

--- a/assets/terraform-05-teamwork/src_1/variables.tf
+++ b/assets/terraform-05-teamwork/src_1/variables.tf
@@ -19,22 +19,6 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
-
-variable "public_key" {
-  type    = string
-  default = ""
-}
 
 variable "username" {
   type = string

--- a/terraform-05-teamwork.md
+++ b/terraform-05-teamwork.md
@@ -201,7 +201,9 @@ By bridgecrew.io | version: 2.3.314
 2. Проверье код с помощью tflint и checkov, исправьте все предупреждения и ошибки в 'terraform-hotfix', сделайте комит.
 3. Откройте новый pull request 'terraform-hotfix' --> 'terraform-05'. 
 4. Вставьте в комментарий PR результат анализа tflint и checkov, план изменений инфраструктуры из вывода команды terraform plan.
-5. Пришлите ссылку на PR для ревью(вливать код в 'terraform-05' не нужно).
+5. Пришлите ссылку на PR для ревью(вливать код в 'terraform-05' не нужно).  
+
+[Ссылка на pull request](https://github.com/VitaliySid/devops-netology/pull/1)
 
 <details>
 <summary>Анализ `src_1`</summary>

--- a/terraform-05-teamwork.md
+++ b/terraform-05-teamwork.md
@@ -163,7 +163,7 @@ Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
 <details>
 <summary>Проект `src`</summary>
 
-```
+```sh
 qwuen@MSI:/mnt/d/projects/devops-netology/assets/terraform-05-teamwork$ checkov -d src/
 [ secrets framework ]: 100%|████████████████████|[4/4], Current File Scanned=src/variables.tf
 [ terraform framework ]: 100%|████████████████████|[3/3], Current File Scanned=variables.tf
@@ -202,6 +202,64 @@ By bridgecrew.io | version: 2.3.314
 3. Откройте новый pull request 'terraform-hotfix' --> 'terraform-05'. 
 4. Вставьте в комментарий PR результат анализа tflint и checkov, план изменений инфраструктуры из вывода команды terraform plan.
 5. Пришлите ссылку на PR для ревью(вливать код в 'terraform-05' не нужно).
+
+<details>
+<summary>Анализ `src_1`</summary>
+
+```sh
+qwuen@MSI:/mnt/d/projects/devops-netology/assets/terraform-05-teamwork$ checkov -d src_1/
+[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
+[ secrets framework ]: 100%|████████████████████|[6/6], Current File Scanned=src_1/vpc_2/variables.tf
+[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
+2023-07-08 10:18:04,635 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=main:None (for external modules, the --download-external-modules flag is required)
+[ terraform framework ]: 100%|████████████████████|[5/5], Current File Scanned=vpc_2/variables.tf
+
+       _               _
+   ___| |__   ___  ___| | _______   __
+  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
+ | (__| | | |  __/ (__|   < (_) \ V /
+  \___|_| |_|\___|\___|_|\_\___/ \_/
+
+By bridgecrew.io | version: 2.3.314
+
+terraform scan results:
+
+Passed checks: 0, Failed checks: 1, Skipped checks: 0
+
+Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
+        FAILED for resource: test-vm
+        File: /main.tf:43-59
+
+                43 | module "test-vm" {
+                44 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+                45 |   env_name       = "develop"
+                46 |   network_id     = module.vpc_dev.vpc_id
+                47 |   subnet_zones   = module.vpc_dev.vpc_zones
+                48 |   subnet_ids     = module.vpc_dev.subnet_ids
+                49 |   instance_name  = "web"
+                50 |   instance_count = 1
+                51 |   image_family   = "ubuntu-2004-lts"
+                52 |   public_ip      = true
+                53 |
+                54 |   metadata = {
+                55 |     user-data          = data.template_file.cloudinit.rendered
+                56 |     serial-port-enable = 1
+                57 |   }
+                58 |
+                59 | }
+
+
+qwuen@MSI:/mnt/d/projects/devops-netology/assets/terraform-05-teamwork$ tflint --chdir src_1
+6 issue(s) found:
+
+src_1/main.tf:44:20: Warning - Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)
+src_1/main.tf:3:14: Warning - Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)
+src_1/main.tf:62:1: Warning - Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)
+src_1/variables.tf:28:1: Warning - variable "vpc_name" is declared but not used (terraform_unused_declarations)
+src_1/variables.tf:34:1: Warning - variable "public_key" is declared but not used (terraform_unused_declarations)
+src_1/variables.tf:22:1: Warning - variable "default_cidr" is declared but not used (terraform_unused_declarations)
+```
+</details>
 
 ------
 ### Задание 4


### PR DESCRIPTION
qwuen@MSI:/mnt/d/projects/devops-netology/assets/terraform-05-teamwork$ checkov -d src_1/
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ secrets framework ]: 100%|████████████████████|[6/6], Current File Scanned=src_1/vpc_2/variables.tf
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
2023-07-08 10:18:04,635 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=main:None (for external modules, the --download-external-modules flag is required)
[ terraform framework ]: 100%|████████████████████|[5/5], Current File Scanned=vpc_2/variables.tf

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.3.314

terraform scan results:

Passed checks: 0, Failed checks: 1, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: test-vm
        File: /main.tf:43-59

                43 | module "test-vm" {
                44 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                45 |   env_name       = "develop"
                46 |   network_id     = module.vpc_dev.vpc_id
                47 |   subnet_zones   = module.vpc_dev.vpc_zones
                48 |   subnet_ids     = module.vpc_dev.subnet_ids
                49 |   instance_name  = "web"
                50 |   instance_count = 1
                51 |   image_family   = "ubuntu-2004-lts"
                52 |   public_ip      = true
                53 |
                54 |   metadata = {
                55 |     user-data          = data.template_file.cloudinit.rendered
                56 |     serial-port-enable = 1
                57 |   }
                58 |
                59 | }


qwuen@MSI:/mnt/d/projects/devops-netology/assets/terraform-05-teamwork$ tflint --chdir src_1
6 issue(s) found:

src_1/main.tf:44:20: Warning - Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)
src_1/main.tf:3:14: Warning - Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)
src_1/main.tf:62:1: Warning - Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)
src_1/variables.tf:28:1: Warning - variable "vpc_name" is declared but not used (terraform_unused_declarations)
src_1/variables.tf:34:1: Warning - variable "public_key" is declared but not used (terraform_unused_declarations)
src_1/variables.tf:22:1: Warning - variable "default_cidr" is declared but not used (terraform_unused_declarations)